### PR TITLE
feat: Simplified goal node labels to show "XX% of $X,XXX" format

### DIFF
--- a/src/components/dashboard/sankey/SankeyChart.tsx
+++ b/src/components/dashboard/sankey/SankeyChart.tsx
@@ -461,44 +461,20 @@ export const SankeyChart = ({ data, height = 500 }: SankeyChartProps) => {
           const textAnchor = isLeftSide ? "start" : "end";
           
           if (d.type === "goal") {
-            // For goal nodes, show both current amount and goal target with enhanced formatting
+            // For goal nodes, show percentage and target amount in concise format
             const currentAmount = d.value || 0;
             const goalTarget = UNIFIED_GOAL_TARGETS[d.id] || 0;
             const progressPercent = goalTarget > 0 ? ((currentAmount / goalTarget) * 100).toFixed(1) : "0";
             
-            // Current amount (first line) - enhanced styling
+            // Single line showing progress percentage and goal target
             selection.append("text")
               .attr("x", xPos)
-              .attr("y", Math.max(nodeHeight / 2 + 8, 16))
+              .attr("y", Math.max(nodeHeight / 2 + 16, 24))
               .attr("dy", "0.35em")
               .attr("text-anchor", textAnchor)
-              .text(`Current: $${currentAmount.toLocaleString()}`)
-              .attr("font-size", config.fontSize.value)
-              .attr("font-weight", "600")
-              .attr("fill", "#059669")
-              .style("pointer-events", "none");
-            
-            // Goal target (second line) - enhanced styling
-            selection.append("text")
-              .attr("x", xPos)
-              .attr("y", Math.max(nodeHeight / 2 + 24, 32))
-              .attr("dy", "0.35em")
-              .attr("text-anchor", textAnchor)
-              .text(`Goal: $${goalTarget.toLocaleString()}`)
+              .text(`${progressPercent}% of $${goalTarget.toLocaleString()}`)
               .attr("font-size", config.fontSize.value)
               .attr("font-weight", "500")
-              .attr("fill", "#1D4ED8")
-              .style("pointer-events", "none");
-              
-            // Progress indicator (third line) - new addition
-            selection.append("text")
-              .attr("x", xPos)
-              .attr("y", Math.max(nodeHeight / 2 + 40, 48))
-              .attr("dy", "0.35em")
-              .attr("text-anchor", textAnchor)
-              .text(`${progressPercent}% complete`)
-              .attr("font-size", "10px")
-              .attr("font-weight", "400")
               .attr("fill", "#6B7280")
               .style("pointer-events", "none");
           } else {


### PR DESCRIPTION
## Simplified Goal Node Labels in Sankey Chart

This PR simplifies the goal node labels in the SankeyChart component based on user feedback to show a more concise format.

### Changes Made

#### 🎯 **Simplified Goal Display**
- **Removed**: Current amount display from the visible labels
- **Changed**: Three-line display to single-line format
- **New Format**: `"XX.X% of $X,XXX"` (e.g., "73.7% of $3,500")

#### ✨ **Visual Improvements**
- **Cleaner Layout**: Single line reduces visual clutter
- **Better Readability**: More concise information at a glance
- **Consistent Styling**: Maintained responsive font sizing and positioning

#### 🔧 **Technical Changes**
- Simplified label generation logic for goal nodes
- Maintained current amount information in tooltips for detailed view
- Preserved existing functionality for non-goal nodes
- Kept detailed breakdown in hover tooltips

### Key Benefits

1. **Reduced Visual Clutter**: Single line instead of three lines for goal nodes
2. **Quick Progress Understanding**: Percentage shows completion at a glance
3. **Clear Target Visibility**: Target amount remains visible for context
4. **Detailed Info Available**: Current amount still accessible via tooltips

### Example Display

**Before (3 lines):**
```
Current: $2,575
Goal: $3,500  
73.7% complete
```

**After (1 line):**
```
73.7% of $3,500
```

### Testing

- ✅ Goal nodes display simplified format correctly
- ✅ Tooltips still show detailed breakdown including current amount
- ✅ Non-goal nodes maintain existing single-line display
- ✅ Responsive design preserved across all screen sizes
- ✅ No breaking changes to existing functionality

This change provides a cleaner, more concise display while keeping all detailed information easily accessible through tooltips.